### PR TITLE
Fix first header rendering

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -35,7 +35,7 @@ const Header: FC = () => {
     return function cleanup() {
       next?.removeEventListener('scroll', headerColorChange);
     };
-  });
+  }, []);
 
   return (
     <AntHeader className={`header ${isScrolled ? 'scrolled' : 'unscrolled'}`}>


### PR DESCRIPTION
1. Move next definition into useEffect.
2. Correct class handling by using useState.